### PR TITLE
Fix formatting issue in README

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -100,8 +100,9 @@ fun VoyagerNavigation() {
     screen: Screen,
     skipHalfExpanded: Boolean = false,
     fixedHeight: Double = 0.0
-)
-``` 
+  )
+  ```
+
 showX has two extra parameters `skipHalfExpanded` and `fixedHeight` which are optional and can be used to skip the half expanded state and set the fixed height of the bottom sheet respectively for IOS.
 
 **Navigation Compose**

--- a/README.MD
+++ b/README.MD
@@ -103,7 +103,7 @@ fun VoyagerNavigation() {
   )
   ```
 
-showX has two extra parameters `skipHalfExpanded` and `fixedHeight` which are optional and can be used to skip the half expanded state and set the fixed height of the bottom sheet respectively for IOS.
+  showX has two extra parameters `skipHalfExpanded` and `fixedHeight` which are optional and can be used to skip the half expanded state and set the fixed height of the bottom sheet respectively for IOS.
 
 **Navigation Compose**
 

--- a/README.MD
+++ b/README.MD
@@ -102,7 +102,6 @@ fun VoyagerNavigation() {
     fixedHeight: Double = 0.0
   )
   ```
-
   showX has two extra parameters `skipHalfExpanded` and `fixedHeight` which are optional and can be used to skip the half expanded state and set the fixed height of the bottom sheet respectively for IOS.
 
 **Navigation Compose**


### PR DESCRIPTION
This PR fixes a little formatting issue in `README.md`

Before / After

<img width="350" alt="Screenshot 2024-12-09 at 19 15 30" src="https://github.com/user-attachments/assets/58d6b810-f3b0-4146-974f-ed708fe588e5">
<img width="350" alt="Screenshot 2024-12-09 at 19 18 17" src="https://github.com/user-attachments/assets/da532eac-058f-4aa4-83a9-00bf1176b20f">
