### PR TITLE
added argument passing to compose navigation sample

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/kashif/sample/compose/ComposeScreens.kt
+++ b/composeApp/src/commonMain/kotlin/com/kashif/sample/compose/ComposeScreens.kt
@@ -23,19 +23,19 @@ object MovieScreenRoute : VoyantRoute {
             Text(
                 "Movie Screen",
                 modifier = Modifier.padding(16.dp).align(Alignment.Center).clickable {
-                    navController.navigateX(MovieDetailsScreenRoute)
+                    navController.navigateX(MovieDetailsScreenRoute("Movie Name"))
                 })
         }
     }
 }
 
 @Serializable
-object MovieDetailsScreenRoute : VoyantRoute {
+data class MovieDetailsScreenRoute(val movieName: String) : VoyantRoute {
     @Composable
     override fun content(navController: NavController) {
         Box(modifier = Modifier.fillMaxSize()) {
             Text(
-                "Movie details Screen",
+                "Movie details Screen $movieName",
                 modifier = Modifier.padding(16.dp).align(Alignment.Center).clickable {
                     navController.popBackStackX()
                 })


### PR DESCRIPTION
closes #18 

This pull request includes changes to the `ComposeScreens.kt` file to enhance the navigation and display of movie details in the compose application. The most important changes include modifying the `MovieScreenRoute` to pass a movie name to the `MovieDetailsScreenRoute` and updating the `MovieDetailsScreenRoute` to use this movie name in its display.

Changes to navigation and display:

* [`composeApp/src/commonMain/kotlin/com/kashif/sample/compose/ComposeScreens.kt`](diffhunk://#diff-e09f3d560fb5c8db7a427e8137b509454c0d3d200fc06ec3d83f680d4ae0472fL26-R38): Modified the `MovieScreenRoute` to pass a movie name when navigating to the `MovieDetailsScreenRoute`.
* [`composeApp/src/commonMain/kotlin/com/kashif/sample/compose/ComposeScreens.kt`](diffhunk://#diff-e09f3d560fb5c8db7a427e8137b509454c0d3d200fc06ec3d83f680d4ae0472fL26-R38): Changed `MovieDetailsScreenRoute` from an object to a data class that takes a `movieName` parameter and updated the displayed text to include the movie name.